### PR TITLE
build with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 2.8.9)
+
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+
+include(CheckCCompilerFlag)
+include(CheckSymbolExists)
+include(CheckCSourceCompiles)
+include(CheckPrototypeDefinition)
+include(CheckTypeSize)
+include(generate_version)
+
+project (dnrd C)
+
+
+include_directories(${CMAKE_BINARY_DIR}/gen)
+set(CMAKE_C_FLAGS "-g -Os")
+
+
+
+find_library(CONFIG_LIBRARIES NAMES pthread)
+find_library(CONFIG_LIBRARIES NAMES config)
+find_library(CONFIG_LIBRARIES NAMES unistd)
+
+check_symbol_exists("usleep" "unistd.h" HAVE_USLEEP)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/build.h.in ${CMAKE_BINARY_DIR}/gen/generated/build.h)
+
+add_executable(dnrd
+src/args.c
+src/cache.c
+src/check.c
+src/common.c
+src/dns.c
+src/domnode.c
+src/lib.c
+src/main.c
+src/master.c
+src/qid.c
+src/query.c
+src/rand.c
+src/relay.c
+src/sig.c
+src/srvnode.c
+src/tcp.c
+src/udp.c
+)
+
+target_link_libraries(dnrd ${CONFIG_LIBRARIES})
+#target_link_libraries(dnrd ${CONFIG_LIBRARIES})
+

--- a/cmake/generate_version.cmake
+++ b/cmake/generate_version.cmake
@@ -1,0 +1,13 @@
+set(VERSION_FILE "${CMAKE_BINARY_DIR}/gen/generated/version.h")
+
+add_custom_target(
+    version
+    COMMAND mkdir -p "${CMAKE_BINARY_DIR}/gen/generated"
+    COMMAND echo "#pragma once" > "${VERSION_FILE}.new"
+    COMMAND sh -c "echo \"#define PACKAGE_VERSION \\\"$(git --git-dir=./.git describe --dirty 2>/dev/null || echo ${PACKAGE_VERSION})\\\"\"" >> "${VERSION_FILE}.new"
+    COMMAND cmp -s "${VERSION_FILE}" "${VERSION_FILE}.new" && rm "${VERSION_FILE}.new" || mv "${VERSION_FILE}.new" "${VERSION_FILE}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    VERBATIM
+)
+set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES "${VERSION_FILE}")
+

--- a/src/build.h.in
+++ b/src/build.h.in
@@ -1,0 +1,5 @@
+
+
+#pragma once 
+/* this is set if the platform has usleep */
+#cmakedefine HAVE_USLEEP

--- a/src/common.c
+++ b/src/common.c
@@ -35,6 +35,8 @@
 #include "common.h"
 #include "lib.h"
 #include "dns.h"
+#include <generated/build.h>
+#include <generated/version.h>
 
 #ifdef DEBUG
 #define OPT_DEBUG 1

--- a/src/common.h
+++ b/src/common.h
@@ -33,6 +33,7 @@
 #include <syslog.h>
 #include <semaphore.h>
 #include "domnode.h"
+#include <generated/build.h>
 
 /* default chroot path. this might be redefined in compile time */ 
 #ifndef DNRD_ROOT

--- a/src/lib.c
+++ b/src/lib.c
@@ -37,7 +37,6 @@
 
 
 #include "lib.h"
-#include "common.h"
 
 /*
 #define	DEBUG(x)		

--- a/src/lib.h
+++ b/src/lib.h
@@ -30,7 +30,7 @@
 #include <time.h>
 #include <signal.h>
 #include <unistd.h>
-
+#include "common.h"
 
 extern char *program;
 extern int verbose;


### PR DESCRIPTION
This allows to build dnrd with cmake which will allow for suitable integration into the openwrt packaging system. Also it allows people to build the code directly from git - the howto in the readme does not work any more
